### PR TITLE
Added script to instruct users to run

### DIFF
--- a/update_id.sh
+++ b/update_id.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+
+export PROJ_FILE="./Loop.xcodeproj/project.pbxproj"
+
+echo -n "Enter a new handle.  A single word, usually lower-case, no special characters: "
+read NEW_HANDLE
+
+sed -i '' "s/MAIN_APP_BUNDLE_IDENTIFIER = com\..*\.Loop/MAIN_APP_BUNDLE_IDENTIFIER = com.${NEW_HANDLE}.Loop/g" "${PROJ_FILE}"
+
+open Loop.xcodeproj


### PR DESCRIPTION
This will allow users to easily update the MAIN_APP_BUNDLE_IDENTIFIER without confusion.  Run it, give the new handle and it will open the project
source update_id.sh