### PR TITLE
Fix for display of glucose

### DIFF
--- a/Loop/Views/GlucoseHUDView.swift
+++ b/Loop/Views/GlucoseHUDView.swift
@@ -33,6 +33,9 @@ final class GlucoseHUDView: HUDView {
         let numberFormatter = NSNumberFormatter()
         numberFormatter.numberStyle = .DecimalStyle
         numberFormatter.minimumFractionDigits = unit.preferredMinimumFractionDigits
+        numberFormatter.usesSignificantDigits = true
+        numberFormatter.minimumSignificantDigits = 2
+        numberFormatter.maximumSignificantDigits = 3
         glucoseLabel.text = numberFormatter.stringFromNumber(glucoseValue.quantity.doubleValueForUnit(unit))
 
         var unitStrings = [unit.glucoseUnitDisplayString]


### PR DESCRIPTION
This should work for mg/dl and mmol/L as there is only ever 3 significant digits at most, sometimes 2 when glucose is <=99mg/dl or <=5.5mmol/L

Tested and fixes https://github.com/loudnate/Loop/issues/159